### PR TITLE
Pieter patch 1 (OneShot mode working)

### DIFF
--- a/example/Src/mcp3564.c
+++ b/example/Src/mcp3564.c
@@ -95,6 +95,64 @@ void MCP3561_Init(SPI_HandleTypeDef *hspi){
 
 
 }
+void MCP3561_Init_One_Shot(SPI_HandleTypeDef *hspi){
+	uint8_t cmd[4] = {0,0,0,0};
+
+	// be careful with the bitwise or operator "|"
+	cmd[0]  = MCP3561_CONFIG0_WRITE;
+	cmd[1]  = MCP3561_CONFIG0_CLK_SEL_EXT;   // clock selection
+	cmd[1] |= MCP3561_CONFIG0_ADC_MODE_CONV; // standby or converting
+	cmd[1] |= MCP3561_CONFIG0_CS_SEL_NONE;   // input current
+	_MCP3561_write(hspi, cmd, 2);
+
+	cmd[0]  = MCP3561_CONFIG1_WRITE;
+	cmd[1]  = MCP3561_CONFIG1_OSR_20480;      // over sampling rate MCP3561_CONFIG1_OSR_20480
+	cmd[1] |= MCP3561_CONFIG1_AMCLK_DIV8;    // sampling clock prescaler
+	_MCP3561_write(hspi, cmd, 2);
+
+	cmd[0]  = MCP3561_CONFIG2_WRITE;
+	cmd[1]  = MCP3561_CONFIG2_BOOST_x1;   // Boost
+	cmd[1] |= MCP3561_CONFIG2_GAIN_x1;    // Gain
+	cmd[1] |= MCP3561_CONFIG2_AZ_MUX_ON; // offset cancellation algorithm
+	cmd[1] += 3; // last two bytes must always be '11'
+	_MCP3561_write(hspi, cmd, 2);
+
+	cmd[0]  = MCP3561_CONFIG3_WRITE;
+	cmd[1]  = MCP3561_CONFIG3_CONV_MODE_ONE_SHOT_STANDBY; // conversion mode
+	//cmd[1]  = MCP3561_CONFIG3_CONV_MODE_CONTINUOUS; // conversion mode
+	cmd[1] |= MCP3561_CONFIG3_DATA_FORMAT_32BIT_CHID_SGN;    // SPI output data format, (32 and 24 bit available)
+	cmd[1] |= MCP3561_CONFIG3_CRCCOM_OFF;           // CRC
+	cmd[1] |= MCP3561_CONFIG3_GAINCAL_OFF;          // gain calibration
+	cmd[1] |= MCP3561_CONFIG3_OFFCAL_ON;           // offset calibration
+	_MCP3561_write(hspi, cmd, 2);
+
+	cmd[0]  = MCP3561_IRQ_WRITE;
+	cmd[1]  = MCP3561_IRQ_MODE_IRQ_HIGH;  // IRQ default pin state
+	cmd[1] |= MCP3561_IRQ_FASTCMD_ON;     // fast commands
+	cmd[1] |= MCP3561_IRQ_STP_ON;         // start of conversion IRQ
+	_MCP3561_write(hspi, cmd, 2);
+
+
+	cmd[0]  = MCP3561_MUX_WRITE;
+	cmd[1]  = (MCP3561_MUX_CH_AGND << 4) | MCP3561_MUX_CH0;
+	//cmd[1]  = (MCP3561_MUX_CH_AGND << 4) | MCP3561_MUX_CH0;         //Deze werkt
+	//cmd[1]  = (MCP3561_MUX_CH1 << 4) | MCP3561_MUX_CH_IntTemp_P;   // [7..4] VIN+ / [3..0] VIN- ;
+	_MCP3561_write(hspi, cmd, 2);
+
+
+	// configure SCAN mode to automatically cycle through channels
+	// only available for MCP3562 and MCP356^4, and only for certain input combinations
+	// @see Datasheet Table 5-14 on p. 54
+
+/*
+	cmd[0] = MCP3561_SCAN_WRITE;
+	cmd[1] = MCP3561_SCAN_DLY_NONE;
+	cmd[2] = 0b00011000;  // enable channel 1
+	cmd[3] = 0;
+	_MCP3561_write(hspi, cmd, 4);
+*/
+}
+
 
 /**
  * @brief prints the configuration registers content


### PR DESCRIPTION
OneShot mode function:
Takes 1 converstion and waits till trigger of timer and takes another converstion

User defines in .h file:
```
//user commands
#define readConversionData		0b01000011; // Device address 1, incremental read starting at register address 0 (ADC Data register) 0x43
#define fullResetFastCmd		0b01111000; // Fast command to reset device 0x78
#define startConversionFastCmd  0b01101000; // Fast command to start a conversion 0x68
```